### PR TITLE
fix: allow workers to be accessed from the master

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ module "network" {
   pod_cidr_range     = var.pod_cidr_range
   service_cidr_range = var.service_cidr_range
   master_cidr_range  = var.master_cidr_range
+  workers_ports_from_master = var.network_allow_workers_ports_from_master
 }
 
 module "cluster" {

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -21,8 +21,8 @@ resource "google_compute_subnetwork" "vpc_subnet" {
   }
 }
 
-resource "google_compute_firewall" "allow_ssh_workers_from_masters" {
-  name      = "${var.cluster_name}-allow-ssh-workers-from-masters"
+resource "google_compute_firewall" "allow_workers_from_master" {
+  name      = "${var.cluster_name}-allow-workers-from-master"
   network   = google_compute_network.cluster_vpc.name
   direction = "INGRESS"
 
@@ -32,7 +32,7 @@ resource "google_compute_firewall" "allow_ssh_workers_from_masters" {
 
   allow {
     protocol = "tcp"
-    ports    = ["443", "6443"]
+    ports    = var.workers_ports_from_master
   }
 
   source_ranges = [var.master_cidr_range]

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -18,5 +18,4 @@ variable "master_cidr_range" {
 
 variable "workers_ports_from_master" {
   type = list
-  default = ["443", "6443", "8443"]
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -16,3 +16,7 @@ variable "service_cidr_range" {
 variable "master_cidr_range" {
 }
 
+variable "workers_ports_from_master" {
+  type = list
+  default = ["443", "6443", "8443"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,3 +8,6 @@ output "cluster_ca_certificate" {
   sensitive = true
 }
 
+output "cluster_network_name" {
+  value = google_compute_network.cluster_vpc.name
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,5 +9,5 @@ output "cluster_ca_certificate" {
 }
 
 output "cluster_network_name" {
-  value = google_compute_network.cluster_vpc.name
+  value = module.network.network_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -106,6 +106,11 @@ variable "enable_calico" {
   default = true
 }
 
+variable "network_allow_workers_ports_from_master" {
+  type = list
+  default = ["443", "6443", "8443"]
+}
+
 variable "init_nodes" {
 }
 


### PR DESCRIPTION
- You can control whether kube-apiserver resolves endpoints or speaks to service IPs using the --enable-aggregator-routing option. GKE enables that option, because service IPs are not routable from the API server.
- That means that any admission controllers need to call from master to workers and the node ports to be reachable. 
- This PR introduces the ability to configure the list of ports and sets a sensible default